### PR TITLE
block の description の代わりに関連パーツ数を表示する

### DIFF
--- a/app/views/blocks/index.html.erb
+++ b/app/views/blocks/index.html.erb
@@ -15,6 +15,7 @@
             <th>Block Number</th>
             <th>Block Name</th>
             <th>Total Price</th>
+            <th>Parts Count</th>
             <th>Description</th>
             <th>Actions</th>
         </tr>
@@ -25,6 +26,7 @@
             <td><%= block.block_number %></td>
             <td><%= block.block_name %></td>
             <td><%= number_to_currency(block.total_related_price, precision: 0) %></td>
+            <td><%= block.parts.count %></td>
             <td><%= block.description %></td>
             <td>
                 <!-- モーダル起動ボタン -->


### PR DESCRIPTION
Fixes #79